### PR TITLE
Remove unnecessary end tag in lists

### DIFF
--- a/src/nbeet/internal/encoder.gleam
+++ b/src/nbeet/internal/encoder.gleam
@@ -82,7 +82,7 @@ fn encode_list(list: List(Tag)) {
         list.fold(list, <<>>, fn(bit_array, tag) {
           bit_array.append(bit_array, encode_tag(tag))
         })
-      <<type_id:int, length:size(32), encoded_tags:bits, type_id.end:int>>
+      <<type_id:int, length:size(32), encoded_tags:bits>>
     }
     _ -> <<type_id.end:int, 0:size(32)>>
   }


### PR DESCRIPTION
Minecraft only uses TAG_End at the end of compound tags, not at the end of list tags (see https://minecraft.wiki/w/NBT_format#Binary_format). Without this change, lists can end their parent compound tag prematurely.