### PR TITLE
mutf-8 support

### DIFF
--- a/src/nbeet/internal/decoder.gleam
+++ b/src/nbeet/internal/decoder.gleam
@@ -1,10 +1,10 @@
-import gleam/bit_array
 import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic, from}
 import gleam/dynamic/decode
 import gleam/list
 import gleam/pair
 import gleam/result
+import nbeet/internal/mutf8
 import nbeet/internal/type_id as type_ids
 
 type DecoderResult =
@@ -142,8 +142,7 @@ fn decode_string(bit_array: BitArray) {
 }
 
 fn string_from_bytes(bit_array: BitArray) {
-  bit_array.to_string(bit_array)
-  |> result.replace_error(Nil)
+  mutf8.string_from_bitarray(bit_array) |> result.replace_error(Nil)
 }
 
 fn decode_list(bit_array: BitArray) {

--- a/src/nbeet/internal/encoder.gleam
+++ b/src/nbeet/internal/encoder.gleam
@@ -3,7 +3,7 @@ import gleam/bytes_tree
 import gleam/dict
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/string
+import nbeet/internal/mutf8
 import nbeet/internal/tag.{type Tag}
 import nbeet/internal/type_id
 
@@ -69,8 +69,9 @@ fn encode_byte_array(byte_array: BitArray) {
 }
 
 fn encode_string(string: String) {
-  let length = string.length(string)
-  <<length:int-big-size(16), string:utf8>>
+  let bytes = mutf8.bitarray_from_string(string)
+  let length = bit_array.byte_size(bytes)
+  <<length:int-big-size(16), bytes:bits>>
 }
 
 fn encode_list(list: List(Tag)) {

--- a/src/nbeet/internal/mutf8.gleam
+++ b/src/nbeet/internal/mutf8.gleam
@@ -1,0 +1,238 @@
+import gleam/bit_array
+import gleam/int
+import gleam/list
+import gleam/result
+import gleam/string
+
+// Encode
+
+pub fn bitarray_from_string(value: String) -> BitArray {
+  bitarray_from_string_impl(<<>>, string.to_utf_codepoints(value))
+}
+
+fn bitarray_from_string_impl(
+  into acc: BitArray,
+  from value: List(UtfCodepoint),
+) -> BitArray {
+  case value {
+    [] -> acc
+    [cp, ..rest] ->
+      case string.utf_codepoint_to_int(cp) {
+        0x00 -> <<0xC0, 0x80>>
+        ord if ord <= 0x7F -> <<ord>>
+        ord if ord <= 0x7FF -> bit_array_from_2_byte_ordinal(ord)
+        ord if ord <= 0xFFFF -> bit_array_from_3_byte_ordinal(ord)
+        ord -> bit_array_from_6_byte_ordinal(ord)
+      }
+      |> bit_array.append(acc, _)
+      |> bitarray_from_string_impl(rest)
+  }
+}
+
+fn bit_array_from_2_byte_ordinal(ord: Int) -> BitArray {
+  let byte1 =
+    ord
+    |> int.bitwise_shift_right(0x06)
+    |> int.bitwise_and(0x1F)
+    |> int.bitwise_or(0xC0)
+  let byte2 = ord |> int.bitwise_and(0x3F) |> int.bitwise_or(0x80)
+
+  <<byte1, byte2>>
+}
+
+fn bit_array_from_3_byte_ordinal(ord: Int) -> BitArray {
+  let byte1 =
+    ord
+    |> int.bitwise_shift_right(0x0C)
+    |> int.bitwise_and(0x0F)
+    |> int.bitwise_or(0xE0)
+  let byte2 =
+    ord
+    |> int.bitwise_shift_right(0x06)
+    |> int.bitwise_and(0x3F)
+    |> int.bitwise_or(0x80)
+  let byte3 = ord |> int.bitwise_and(0x3F) |> int.bitwise_or(0x80)
+
+  <<byte1, byte2, byte3>>
+}
+
+fn bit_array_from_6_byte_ordinal(ord: Int) -> BitArray {
+  // 11101101 1010wwww 10xxxxxx 11101101 1011yyyy 10zzzzzz
+  let byte1 = 0xED
+  let byte2 =
+    { int.bitwise_shift_right(ord, 0x10) - 1 }
+    |> int.bitwise_and(0x0F)
+    |> int.bitwise_or(0xA0)
+  let byte3 =
+    ord
+    |> int.bitwise_shift_right(0x0A)
+    |> int.bitwise_and(0x3F)
+    |> int.bitwise_or(0x80)
+  let byte4 = 0xED
+  let byte5 =
+    ord
+    |> int.bitwise_shift_right(0x06)
+    |> int.bitwise_and(0x0F)
+    |> int.bitwise_or(0xB0)
+  let byte6 = ord |> int.bitwise_and(0x3F) |> int.bitwise_or(0x80)
+
+  <<byte1, byte2, byte3, byte4, byte5, byte6>>
+}
+
+// Decode
+
+pub fn string_from_bitarray(data: BitArray) -> Result(String, String) {
+  string_from_bitarray_impl([], data)
+}
+
+fn string_from_bitarray_impl(
+  into acc: List(UtfCodepoint),
+  from data: BitArray,
+) -> Result(String, String) {
+  use expected_bytes <- result.try(get_expected_bytes(data))
+
+  case data, expected_bytes {
+    <<>>, 0 -> Ok(string.from_utf_codepoints(acc))
+
+    <<0, _rest:bits>>, _ -> Error("Embedded null byte in string bytes")
+
+    <<byte1, rest:bits>>, 1 -> {
+      use codepoint <- result.try(codepoint_from_1_byte(byte1))
+      string_from_bitarray_impl(list.append(acc, [codepoint]), rest)
+    }
+
+    <<byte1, byte2, rest:bits>>, 2 -> {
+      use codepoint <- result.try(codepoint_from_2_bytes(byte1, byte2))
+      string_from_bitarray_impl(list.append(acc, [codepoint]), rest)
+    }
+
+    <<byte1, byte2, byte3, rest:bits>>, 3 -> {
+      use codepoint <- result.try(codepoint_from_3_bytes(byte1, byte2, byte3))
+      string_from_bitarray_impl(list.append(acc, [codepoint]), rest)
+    }
+
+    <<byte1, byte2, byte3, byte4, byte5, byte6, rest:bits>>, 6 -> {
+      use codepoint <- result.try(codepoint_from_6_bytes(
+        byte1,
+        byte2,
+        byte3,
+        byte4,
+        byte5,
+        byte6,
+      ))
+      string_from_bitarray_impl(list.append(acc, [codepoint]), rest)
+    }
+
+    _, expected ->
+      Error(
+        "Expected a "
+        <> int.to_string(expected)
+        <> "-byte character but there weren't enough left",
+      )
+  }
+}
+
+fn get_expected_bytes(data: BitArray) -> Result(Int, String) {
+  case data {
+    <<>> -> Ok(0)
+
+    <<byte1, rest:bits>> ->
+      case int.bitwise_and(byte1, 0xE0), int.bitwise_and(byte1, 0xF0) {
+        0xC0, _ -> Ok(2)
+
+        _, 0xE0 ->
+          case rest {
+            <<byte2, _byte3, rest2:bits>> ->
+              case byte1, int.bitwise_and(byte2, 0xF0) {
+                0xED, 0xA0 ->
+                  case rest2 {
+                    <<byte4, byte5, _rest3:bits>> ->
+                      case byte4, int.bitwise_and(byte5, 0xF0) {
+                        0xED, 0xB0 -> Ok(6)
+
+                        _, _ -> Ok(3)
+                      }
+
+                    _ -> Ok(3)
+                  }
+
+                _, _ -> Ok(3)
+              }
+
+            _ ->
+              Error(
+                "Got an indicator for a 3 or 6 byte character but there aren't enough bytes left",
+              )
+          }
+
+        _, _ -> Ok(1)
+      }
+
+    _ -> Ok(1)
+  }
+}
+
+fn codepoint_from_1_byte(byte1: Int) -> Result(UtfCodepoint, String) {
+  string.utf_codepoint(byte1)
+  |> result.replace_error(
+    "Cannot convert byte to a string char: " <> int.to_string(byte1),
+  )
+}
+
+fn codepoint_from_2_bytes(
+  byte1: Int,
+  byte2: Int,
+) -> Result(UtfCodepoint, String) {
+  int.bitwise_and(byte1, 0x1F)
+  |> int.bitwise_shift_left(6)
+  |> int.bitwise_or(int.bitwise_and(byte2, 0x3F))
+  |> string.utf_codepoint
+  |> result.replace_error(
+    "Cannot convert bytes to a string char: "
+    <> bit_array.inspect(<<byte1, byte2>>),
+  )
+}
+
+fn codepoint_from_3_bytes(
+  byte1: Int,
+  byte2: Int,
+  byte3: Int,
+) -> Result(UtfCodepoint, String) {
+  int.bitwise_and(byte1, 0x0F)
+  |> int.bitwise_shift_left(0x0C)
+  |> int.bitwise_or(
+    int.bitwise_and(byte2, 0x3F) |> int.bitwise_shift_left(0x06),
+  )
+  |> int.bitwise_or(int.bitwise_and(byte3, 0x3F))
+  |> string.utf_codepoint
+  |> result.replace_error(
+    "Cannot convert bytes to a string char: "
+    <> bit_array.inspect(<<byte1, byte2, byte3>>),
+  )
+}
+
+fn codepoint_from_6_bytes(
+  byte1: Int,
+  byte2: Int,
+  byte3: Int,
+  byte4: Int,
+  byte5: Int,
+  byte6: Int,
+) -> Result(UtfCodepoint, String) {
+  0x10000
+  |> int.bitwise_or(
+    int.bitwise_and(byte2, 0x0F) |> int.bitwise_shift_left(0x10),
+  )
+  |> int.bitwise_or(
+    int.bitwise_and(byte3, 0x3F) |> int.bitwise_shift_left(0x0A),
+  )
+  |> int.bitwise_or(
+    int.bitwise_and(byte5, 0x0F) |> int.bitwise_shift_left(0x06),
+  )
+  |> int.bitwise_or(int.bitwise_and(byte6, 0x3F))
+  |> string.utf_codepoint
+  |> result.replace_error(
+    "Cannot convert bytes to a string char: "
+    <> bit_array.inspect(<<byte1, byte2, byte3, byte4, byte5, byte6>>),
+  )
+}

--- a/test/mutf8_test.gleam
+++ b/test/mutf8_test.gleam
@@ -1,0 +1,110 @@
+import gleam/bit_array
+import gleam/dict
+import gleeunit/should
+import nbeet/internal/mutf8
+
+fn cases() {
+  dict.from_list([
+    #("null", #("\u{0000}", <<0xc0, 0x80>>)),
+    #("latin_2_with_stroke", #("ƻ", <<0xc6, 0xbb>>)),
+    #("canadian_syllabics_e", #("ᐁ", <<0xe1, 0x90, 0x81>>)),
+    #("square_kb", #("㎅", <<0xe3, 0x8e, 0x85>>)),
+    #("katakana_tu", #("ッ", <<0xe3, 0x83, 0x83>>)),
+    #(
+      "korean",
+      #("한국어로 문자열이에요", <<
+        0xed, 0x95, 0x9c, 0xea, 0xb5, 0xad, 0xec, 0x96, 0xb4, 0xeb, 0xa1, 0x9c,
+        0x20, 0xeb, 0xac, 0xb8, 0xec, 0x9e, 0x90, 0xec, 0x97, 0xb4, 0xec, 0x9d,
+        0xb4, 0xec, 0x97, 0x90, 0xec, 0x9a, 0x94,
+      >>),
+    ),
+    #("deseret_long_e_capital", #("𐐁", <<0xED, 0xA0, 0x81, 0xED, 0xB0, 0x81>>)),
+    #("deseret_short_a_capital", #("𐐈", <<0xED, 0xA0, 0x81, 0xED, 0xB0, 0x88>>)),
+  ])
+}
+
+fn from_bit_array_case(c: String) {
+  case cases() |> dict.get(c) {
+    Ok(#(s, b)) -> b |> mutf8.string_from_bitarray() |> should.equal(Ok(s))
+    Error(_) -> panic as { "Missing from bit array test case: " <> c }
+  }
+}
+
+fn from_string_case(c: String) {
+  case cases() |> dict.get(c) {
+    Ok(#(s, b)) ->
+      s
+      |> mutf8.bitarray_from_string()
+      |> bit_array.inspect()
+      |> should.equal(b |> bit_array.inspect())
+    Error(_) -> panic as { "Missing from bit array test case: " <> c }
+  }
+}
+
+// From bit_array
+
+pub fn null_from_bitarray_test() {
+  "null" |> from_bit_array_case
+}
+
+pub fn latin_2_with_stroke_from_bitarray_test() {
+  "latin_2_with_stroke" |> from_bit_array_case
+}
+
+pub fn canadian_syllabics_e_from_bitarray_test() {
+  "canadian_syllabics_e" |> from_bit_array_case
+}
+
+pub fn square_kb_from_bitarray_test() {
+  "square_kb" |> from_bit_array_case
+}
+
+pub fn katakana_tu_from_bitarray_test() {
+  "katakana_tu" |> from_bit_array_case
+}
+
+pub fn korean_from_bitarray_test() {
+  "korean" |> from_bit_array_case
+}
+
+pub fn deseret_long_e_capital_from_bitarray_test() {
+  "deseret_long_e_capital" |> from_bit_array_case
+}
+
+pub fn deseret_short_a_capital_from_bitarray_test() {
+  "deseret_short_a_capital" |> from_bit_array_case
+}
+
+// From string
+
+pub fn null_from_string_test() {
+  "null" |> from_string_case
+}
+
+pub fn latin_2_with_stroke_from_string_test() {
+  "latin_2_with_stroke" |> from_string_case
+}
+
+pub fn canadian_syllabics_e_from_string_test() {
+  "canadian_syllabics_e" |> from_string_case
+}
+
+pub fn square_kb_from_string_test() {
+  "square_kb" |> from_string_case
+}
+
+pub fn katakana_tu_from_string_test() {
+  "katakana_tu" |> from_string_case
+}
+
+pub fn korean_from_string_test() {
+  "korean" |> from_string_case
+}
+
+pub fn deseret_long_e_capital_from_string_test() {
+  "deseret_long_e_capital" |> from_string_case
+}
+
+pub fn deseret_short_a_capital_from_string_test() {
+  "deseret_short_a_capital" |> from_string_case
+}


### PR DESCRIPTION
Closes #8

Encode and decode strings using modified utf-8 which is the string format used by Java.

The format has 1-byte, 2-byte, 3-byte and 6-byte encodings, plus it uses a 2-byte encoding for a null character.

---

Interesting to note is that when I was adding tests for the 6-byte characters I discovered that a lot of existing NBT tools and libraries used the utf-8 4-byte encoding.

We need to check if Minecraft Java Edition decode 4-byte utf-8 characters or does it expect 6-byte characters.

- If it fails then we should keep the 6-byte encoding and report the bug to the other libraries
- If it works then we should consider to always encode to 4-byte and support reading both 4-byte and 6-byte encodings