### PR TITLE
Feature: Public Tag Type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.0.2"
-          gleam-version: "1.6.3"
+          gleam-version: "1.10.0"
           rebar3-version: "3"
       - run: gleam deps download
       - run: gleam test

--- a/src/nbeet.gleam
+++ b/src/nbeet.gleam
@@ -3,11 +3,14 @@ import gleam/list
 import gleam/option.{None, Some}
 import nbeet/internal/decoder
 import nbeet/internal/encoder
-import nbeet/internal/tag.{type Tag}
+import nbeet/internal/tag
 
 pub opaque type Nbt {
   Nbt(tag: Tag)
 }
+
+pub type Tag =
+  tag.Tag
 
 pub const empty = Nbt(tag.Compound([]))
 


### PR DESCRIPTION
Adds an alias for `tag.Tag` to `nbeet.gleam`. This allows storing tags in other data structures.

Fixes #6 