### PR TITLE
Update to use stdlib 0.61.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.0.2"
-          gleam-version: "1.10.0"
+          gleam-version: "1.11.1"
           rebar3-version: "3"
       - run: gleam deps download
       - run: gleam test

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,9 +6,9 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "zwubs", repo = "nbeet" }
 
 [dependencies]
-gleam_stdlib = ">= 0.51.0 and < 2.0.0"
+gleam_stdlib = ">= 0.61.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
-gleam_erlang = ">= 0.25.0 and < 1.0.0"
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
 simplifile = ">= 2.0.0 and < 3.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,14 +3,14 @@
 
 packages = [
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
-  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
-  { name = "gleam_stdlib", version = "0.59.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F8FEE9B35797301994B81AF75508CF87C328FE1585558B0FFD188DC2B32EAA95" },
-  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
-  { name = "simplifile", version = "2.2.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "C88E0EE2D509F6D86EB55161D631657675AA7684DAB83822F7E59EB93D9A60E3" },
+  { name = "gleam_erlang", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "F91CE62A2D011FA13341F3723DB7DB118541AAA5FE7311BD2716D018F01EF9E3" },
+  { name = "gleam_stdlib", version = "0.61.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3DC407D6EDA98FCE089150C11F3AD892B6F4C3CA77C87A97BAE8D5AB5E41F331" },
+  { name = "gleeunit", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "63022D81C12C17B7F1A60E029964E830A4CBD846BBC6740004FC1F1031AE0326" },
+  { name = "simplifile", version = "2.3.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0A868DAC6063D9E983477981839810DC2E553285AB4588B87E3E9C96A7FB4CB4" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.51.0 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.61.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }

--- a/src/nbeet.gleam
+++ b/src/nbeet.gleam
@@ -81,5 +81,3 @@ pub fn java_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
 pub fn java_network_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
   decoder.java_network_decode(bit_array, decoder)
 }
-
-

--- a/src/nbeet.gleam
+++ b/src/nbeet.gleam
@@ -81,3 +81,5 @@ pub fn java_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
 pub fn java_network_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
   decoder.java_network_decode(bit_array, decoder)
 }
+
+

--- a/src/nbeet.gleam
+++ b/src/nbeet.gleam
@@ -81,7 +81,3 @@ pub fn java_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
 pub fn java_network_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
   decoder.java_network_decode(bit_array, decoder)
 }
-
-pub fn unwrap(nbt: Nbt) -> tag.Tag {
-  nbt.tag
-}

--- a/src/nbeet.gleam
+++ b/src/nbeet.gleam
@@ -78,3 +78,7 @@ pub fn java_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
 pub fn java_network_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
   decoder.java_network_decode(bit_array, decoder)
 }
+
+pub fn unwrap(nbt: Nbt) -> tag.Tag {
+  nbt.tag
+}

--- a/src/nbeet/internal/decoder.gleam
+++ b/src/nbeet/internal/decoder.gleam
@@ -225,9 +225,9 @@ fn decode_list_of_length(
   list: List(Dynamic),
   length: Int,
 ) -> Result(#(List(Dynamic), BitArray), Nil) {
-  case length {
-    l if l < 1 -> Ok(#(list, bit_array))
-    _ -> {
+  case length < 1 {
+    True -> Ok(#(list, bit_array))
+    False -> {
       use #(element, bit_array) <- result.try(decode_tag_of_type(
         bit_array,
         type_id,
@@ -253,9 +253,9 @@ fn decode_compound_elements(
   dict: Dict(String, Dynamic),
 ) -> Result(#(Dict(String, Dynamic), BitArray), Nil) {
   use #(type_id, bit_array) <- result.try(decode_byte(bit_array))
-  case type_id {
-    _ if type_id == type_ids.end -> Ok(#(dict, bit_array))
-    _ -> {
+  case type_id == type_ids.end {
+    True -> Ok(#(dict, bit_array))
+    False -> {
       use #(name, bit_array) <- result.try(decode_string(bit_array))
       use #(value, bit_array) <- result.try(decode_tag_of_type(
         bit_array,

--- a/src/nbeet/internal/decoder.gleam
+++ b/src/nbeet/internal/decoder.gleam
@@ -1,5 +1,5 @@
 import gleam/dict.{type Dict}
-import gleam/dynamic.{type Dynamic, from}
+import gleam/dynamic.{type Dynamic}
 import gleam/dynamic/decode
 import gleam/list
 import gleam/pair
@@ -10,8 +10,11 @@ import nbeet/internal/type_id as type_ids
 type DecoderResult =
   Result(#(Dynamic, BitArray), Nil)
 
-pub fn java_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
-  use #(root_name, dynamic_value) <- result.then(
+pub fn java_decode(
+  bit_array: BitArray,
+  decoder: decode.Decoder(t),
+) -> Result(#(String, t), List(decode.DecodeError)) {
+  use #(root_name, dynamic_value) <- result.try(
     decode_named_root_compound(bit_array)
     |> result.replace_error([]),
   )
@@ -19,8 +22,11 @@ pub fn java_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
   Ok(#(root_name, decoded_value))
 }
 
-pub fn java_network_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
-  use dynamic_value <- result.then(
+pub fn java_network_decode(
+  bit_array: BitArray,
+  decoder: decode.Decoder(t),
+) -> Result(t, List(decode.DecodeError)) {
+  use dynamic_value <- result.try(
     decode_root_compound(bit_array)
     |> result.replace_error([]),
   )
@@ -28,7 +34,9 @@ pub fn java_network_decode(bit_array: BitArray, decoder: decode.Decoder(t)) {
   Ok(decoded_value)
 }
 
-fn decode_named_root_compound(bit_array: BitArray) {
+fn decode_named_root_compound(
+  bit_array: BitArray,
+) -> Result(#(String, Dynamic), Nil) {
   case bit_array {
     <<type_id:int, bit_array:bits>> if type_id == type_ids.compound -> {
       use #(name, bit_array) <- result.try(decode_string(bit_array))
@@ -39,7 +47,7 @@ fn decode_named_root_compound(bit_array: BitArray) {
   }
 }
 
-fn decode_root_compound(bit_array: BitArray) {
+fn decode_root_compound(bit_array: BitArray) -> Result(Dynamic, Nil) {
   case bit_array {
     <<type_id:int, bit_array:bits>> if type_id == type_ids.compound -> {
       use result <- result.try(decode_tag_of_type(bit_array, type_id))
@@ -51,38 +59,98 @@ fn decode_root_compound(bit_array: BitArray) {
 
 fn decode_tag_of_type(bit_array: BitArray, type_id: Int) -> DecoderResult {
   case type_id {
-    _ if type_id == type_ids.end -> wrap(Ok(#(Nil, bit_array)))
-    _ if type_id == type_ids.byte -> wrap(decode_byte(bit_array))
-    _ if type_id == type_ids.short -> wrap(decode_short(bit_array))
-    _ if type_id == type_ids.int -> wrap(decode_int(bit_array))
-    _ if type_id == type_ids.long -> wrap(decode_long(bit_array))
-    _ if type_id == type_ids.float -> wrap(decode_float(bit_array))
-    _ if type_id == type_ids.double -> wrap(decode_double(bit_array))
-    _ if type_id == type_ids.byte_array -> wrap(decode_byte_array(bit_array))
-    _ if type_id == type_ids.string -> wrap(decode_string(bit_array))
-    _ if type_id == type_ids.list -> wrap(decode_list(bit_array))
-    _ if type_id == type_ids.compound -> wrap(decode_compound(bit_array))
-    _ if type_id == type_ids.int_array -> wrap(decode_int_array(bit_array))
-    _ if type_id == type_ids.long_array -> wrap(decode_long_array(bit_array))
+    _ if type_id == type_ids.end -> Ok(#(dynamic.nil(), bit_array))
+    _ if type_id == type_ids.byte -> wrap_int(decode_byte(bit_array))
+    _ if type_id == type_ids.short -> wrap_int(decode_short(bit_array))
+    _ if type_id == type_ids.int -> wrap_int(decode_int(bit_array))
+    _ if type_id == type_ids.long -> wrap_int(decode_long(bit_array))
+    _ if type_id == type_ids.float -> wrap_float(decode_float(bit_array))
+    _ if type_id == type_ids.double -> wrap_float(decode_double(bit_array))
+    _ if type_id == type_ids.byte_array ->
+      wrap_bit_array(decode_byte_array(bit_array))
+    _ if type_id == type_ids.string -> wrap_string(decode_string(bit_array))
+    _ if type_id == type_ids.list -> wrap_list(decode_list(bit_array))
+    _ if type_id == type_ids.compound ->
+      wrap_compound(decode_compound(bit_array))
+    _ if type_id == type_ids.int_array -> wrap_list(decode_int_array(bit_array))
+    _ if type_id == type_ids.long_array ->
+      wrap_list(decode_long_array(bit_array))
     _ -> Error(Nil)
   }
 }
 
-fn wrap(result: Result(#(value, BitArray), Nil)) {
+fn wrap_int(
+  result: Result(#(Int, BitArray), Nil),
+) -> Result(#(Dynamic, BitArray), Nil) {
   case result {
-    Ok(#(value, bit_array)) -> Ok(#(from(value), bit_array))
+    Ok(#(value, bit_array)) -> Ok(#(dynamic.int(value), bit_array))
     _ -> Error(Nil)
   }
 }
 
-fn decode_byte(bit_array: BitArray) {
+fn wrap_float(
+  result: Result(#(Float, BitArray), Nil),
+) -> Result(#(Dynamic, BitArray), Nil) {
+  case result {
+    Ok(#(value, bit_array)) -> Ok(#(dynamic.float(value), bit_array))
+    _ -> Error(Nil)
+  }
+}
+
+fn wrap_bit_array(
+  result: Result(#(BitArray, BitArray), Nil),
+) -> Result(#(Dynamic, BitArray), Nil) {
+  case result {
+    Ok(#(value, bit_array)) -> Ok(#(dynamic.bit_array(value), bit_array))
+    _ -> Error(Nil)
+  }
+}
+
+fn wrap_string(
+  result: Result(#(String, BitArray), Nil),
+) -> Result(#(Dynamic, BitArray), Nil) {
+  case result {
+    Ok(#(value, bit_array)) -> Ok(#(dynamic.string(value), bit_array))
+    _ -> Error(Nil)
+  }
+}
+
+fn wrap_list(
+  result: Result(#(List(Dynamic), BitArray), Nil),
+) -> Result(#(Dynamic, BitArray), Nil) {
+  case result {
+    Ok(#(value, bit_array)) -> Ok(#(dynamic.list(value), bit_array))
+    _ -> Error(Nil)
+  }
+}
+
+fn wrap_compound(
+  result: Result(#(Dict(String, Dynamic), BitArray), Nil),
+) -> Result(#(Dynamic, BitArray), Nil) {
+  case result {
+    Ok(#(value, bit_array)) ->
+      Ok(#(
+        value
+          |> dict.to_list
+          |> list.map(fn(key_val: #(String, Dynamic)) -> #(Dynamic, Dynamic) {
+            let #(key, val) = key_val
+            #(dynamic.string(key), val)
+          })
+          |> dynamic.properties,
+        bit_array,
+      ))
+    _ -> Error(Nil)
+  }
+}
+
+fn decode_byte(bit_array: BitArray) -> Result(#(Int, BitArray), Nil) {
   case bit_array {
     <<byte:int-signed-big-size(8), bit_array:bytes>> -> Ok(#(byte, bit_array))
     _ -> Error(Nil)
   }
 }
 
-fn decode_short(bit_array: BitArray) {
+fn decode_short(bit_array: BitArray) -> Result(#(Int, BitArray), Nil) {
   case bit_array {
     <<short:int-signed-big-size(16), bit_array:bytes>> ->
       Ok(#(short, bit_array))
@@ -90,35 +158,35 @@ fn decode_short(bit_array: BitArray) {
   }
 }
 
-fn decode_int(bit_array: BitArray) {
+fn decode_int(bit_array: BitArray) -> Result(#(Int, BitArray), Nil) {
   case bit_array {
     <<int:int-signed-big-size(32), bit_array:bytes>> -> Ok(#(int, bit_array))
     _ -> Error(Nil)
   }
 }
 
-fn decode_long(bit_array: BitArray) {
+fn decode_long(bit_array: BitArray) -> Result(#(Int, BitArray), Nil) {
   case bit_array {
     <<long:int-signed-big-size(64), bit_array:bytes>> -> Ok(#(long, bit_array))
     _ -> Error(Nil)
   }
 }
 
-fn decode_float(bit_array: BitArray) {
+fn decode_float(bit_array: BitArray) -> Result(#(Float, BitArray), Nil) {
   case bit_array {
     <<float:float-big-size(32), bit_array:bytes>> -> Ok(#(float, bit_array))
     _ -> Error(Nil)
   }
 }
 
-fn decode_double(bit_array: BitArray) {
+fn decode_double(bit_array: BitArray) -> Result(#(Float, BitArray), Nil) {
   case bit_array {
     <<double:float-big-size(64), bit_array:bytes>> -> Ok(#(double, bit_array))
     _ -> Error(Nil)
   }
 }
 
-fn decode_byte_array(bit_array: BitArray) {
+fn decode_byte_array(bit_array: BitArray) -> Result(#(BitArray, BitArray), Nil) {
   use #(length, bit_array) <- result.try(decode_int(bit_array))
   case bit_array {
     <<byte_array:bytes-size(length), bit_array:bytes>> ->
@@ -127,7 +195,7 @@ fn decode_byte_array(bit_array: BitArray) {
   }
 }
 
-fn decode_string(bit_array: BitArray) {
+fn decode_string(bit_array: BitArray) -> Result(#(String, BitArray), Nil) {
   case bit_array {
     <<
       length:int-unsigned-big-size(16),
@@ -141,11 +209,11 @@ fn decode_string(bit_array: BitArray) {
   }
 }
 
-fn string_from_bytes(bit_array: BitArray) {
+fn string_from_bytes(bit_array: BitArray) -> Result(String, Nil) {
   mutf8.string_from_bitarray(bit_array) |> result.replace_error(Nil)
 }
 
-fn decode_list(bit_array: BitArray) {
+fn decode_list(bit_array: BitArray) -> Result(#(List(Dynamic), BitArray), Nil) {
   use #(type_id, bit_array) <- result.try(decode_byte(bit_array))
   use #(length, bit_array) <- result.try(decode_int(bit_array))
   decode_list_of_length(bit_array, type_id, [], length)
@@ -156,7 +224,7 @@ fn decode_list_of_length(
   type_id: Int,
   list: List(Dynamic),
   length: Int,
-) {
+) -> Result(#(List(Dynamic), BitArray), Nil) {
   case length {
     l if l < 1 -> Ok(#(list, bit_array))
     _ -> {
@@ -174,11 +242,16 @@ fn decode_list_of_length(
   }
 }
 
-fn decode_compound(bit_array: BitArray) {
+fn decode_compound(
+  bit_array: BitArray,
+) -> Result(#(Dict(String, Dynamic), BitArray), Nil) {
   decode_compound_elements(bit_array, dict.new())
 }
 
-fn decode_compound_elements(bit_array: BitArray, dict: Dict(String, Dynamic)) {
+fn decode_compound_elements(
+  bit_array: BitArray,
+  dict: Dict(String, Dynamic),
+) -> Result(#(Dict(String, Dynamic), BitArray), Nil) {
   use #(type_id, bit_array) <- result.try(decode_byte(bit_array))
   case type_id {
     _ if type_id == type_ids.end -> Ok(#(dict, bit_array))
@@ -193,12 +266,16 @@ fn decode_compound_elements(bit_array: BitArray, dict: Dict(String, Dynamic)) {
   }
 }
 
-fn decode_int_array(bit_array: BitArray) {
+fn decode_int_array(
+  bit_array: BitArray,
+) -> Result(#(List(Dynamic), BitArray), Nil) {
   use #(length, bit_array) <- result.try(decode_int(bit_array))
   decode_list_of_length(bit_array, type_ids.int, [], length)
 }
 
-fn decode_long_array(bit_array: BitArray) {
+fn decode_long_array(
+  bit_array: BitArray,
+) -> Result(#(List(Dynamic), BitArray), Nil) {
   use #(length, bit_array) <- result.try(decode_int(bit_array))
   decode_list_of_length(bit_array, type_ids.long, [], length)
 }


### PR DESCRIPTION
Updates the package to switch away from `dynamic.from`, which was removed in stdlib 0.61.0. Also swaps the use of `result.then` to `result.try`, as then has been deprecated.