### PR TITLE
Feature/improve mutf8 performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.0.2"
-          gleam-version: "1.11.1"
+          gleam-version: "1.12.0"
           rebar3-version: "3"
       - run: gleam deps download
       - run: gleam test

--- a/src/nbeet/internal/encoder.gleam
+++ b/src/nbeet/internal/encoder.gleam
@@ -69,7 +69,7 @@ fn encode_byte_array(byte_array: BitArray) {
 }
 
 fn encode_string(string: String) {
-  let bytes = mutf8.bitarray_from_string(string)
+  let assert Ok(bytes) = mutf8.bitarray_from_string(string)
   let length = bit_array.byte_size(bytes)
   <<length:int-big-size(16), bytes:bits>>
 }

--- a/src/nbeet/internal/mutf8.gleam
+++ b/src/nbeet/internal/mutf8.gleam
@@ -1,238 +1,198 @@
 import gleam/bit_array
 import gleam/int
-import gleam/list
 import gleam/result
-import gleam/string
+
+//  Case    utf8                                                                        mutf8
+//  ------------------------------------------------------------------------------------------------------------------------------------------
+//  Null    00000000                            <------------special case-------------> 11000000 10000000
+//  1-byte  0yyyzzzz                            <----------------same-----------------> 0yyyzzzz
+//  2-byte  110xxxyy 10yyzzzz                   <----------------same-----------------> 110xxxyy 10yyzzzz
+//  3-byte  1110wwww 10xxxxyy 10yyzzzz          <----------------same-----------------> 1110wwww 10xxxxyy 10yyzzzz
+//  4-byte  11110vvv 10vvwwww 10xxxxyy 10yyzzzz <-v is decremented and cast to 4 bits-> 11101101 1010vvvv 10wwwwxx 11101101 1011xxyy 10yyzzzz
 
 // Encode
 
-pub fn bitarray_from_string(value: String) -> BitArray {
-  bitarray_from_string_impl(<<>>, string.to_utf_codepoints(value))
+pub fn bitarray_from_string(value: String) -> Result(BitArray, String) {
+  bitarray_from_string_impl(value |> bit_array.from_string, <<>>)
 }
 
 fn bitarray_from_string_impl(
-  into acc: BitArray,
-  from value: List(UtfCodepoint),
-) -> BitArray {
-  case value {
-    [] -> acc
-    [cp, ..rest] ->
-      case string.utf_codepoint_to_int(cp) {
-        0x00 -> <<0xC0, 0x80>>
-        ord if ord <= 0x7F -> <<ord>>
-        ord if ord <= 0x7FF -> bit_array_from_2_byte_ordinal(ord)
-        ord if ord <= 0xFFFF -> bit_array_from_3_byte_ordinal(ord)
-        ord -> bit_array_from_6_byte_ordinal(ord)
+  from: BitArray,
+  into: BitArray,
+) -> Result(BitArray, String) {
+  case split_at_first_multibyte(from, 0) {
+    #(<<>>, rest) ->
+      case rest {
+        // Finished
+        <<>> -> Ok(into)
+        // Null
+        <<0, rest:bits>> ->
+          bitarray_from_string_impl(rest, <<into:bits, 0xC0, 0x80>>)
+        // 2-byte
+        <<0b110:size(3), cont:bits-size(13), rest:bits>> ->
+          bitarray_from_string_impl(rest, <<
+            into:bits,
+            0b110:size(3),
+            cont:bits-size(13),
+          >>)
+        // 3-byte
+        <<0b1110:size(4), cont:bits-size(20), rest:bits>> ->
+          bitarray_from_string_impl(rest, <<
+            into:bits,
+            0b1110:size(4),
+            cont:bits-size(20),
+          >>)
+        // 4-byte -> 6-byte
+        <<
+          0b11110:size(5),
+          t:bits-size(3),
+          0b10:size(2),
+          u:bits-size(2),
+          w:bits-size(4),
+          0b10:size(2),
+          x:bits-size(2),
+          y:bits-size(4),
+          0b10:size(2),
+          z:bits-size(6),
+          rest:bits,
+        >> -> {
+          let assert <<v>> = <<0b000:size(3), t:bits-size(3), u:bits-size(2)>>
+          let v = v - 1
+          bitarray_from_string_impl(rest, <<
+            into:bits,
+            0xed,
+            0xa:size(4),
+            v:size(4),
+            0b10:size(2),
+            w:bits-size(4),
+            x:bits-size(2),
+            0xed,
+            0xb:size(4),
+            y:bits-size(4),
+            0b10:size(2),
+            z:bits-size(6),
+          >>)
+        }
+        // Invalid
+        _ -> {
+          let assert <<a, _rest:bits>> = rest
+          let assert Ok(bits) = int.to_base_string(a, 2)
+          Error(
+            "Unexpected bytes while encoding string to mutf8, expected the start of a multi-byte character, next byte is: 0x"
+            <> bits,
+          )
+        }
       }
-      |> bit_array.append(acc, _)
-      |> bitarray_from_string_impl(rest)
+
+    #(mono_bytes, <<>>) -> Ok(<<into:bits, mono_bytes:bits>>)
+
+    #(mono_bytes, rest) ->
+      bitarray_from_string_impl(rest, <<into:bits, mono_bytes:bits>>)
   }
-}
-
-fn bit_array_from_2_byte_ordinal(ord: Int) -> BitArray {
-  let byte1 =
-    ord
-    |> int.bitwise_shift_right(0x06)
-    |> int.bitwise_and(0x1F)
-    |> int.bitwise_or(0xC0)
-  let byte2 = ord |> int.bitwise_and(0x3F) |> int.bitwise_or(0x80)
-
-  <<byte1, byte2>>
-}
-
-fn bit_array_from_3_byte_ordinal(ord: Int) -> BitArray {
-  let byte1 =
-    ord
-    |> int.bitwise_shift_right(0x0C)
-    |> int.bitwise_and(0x0F)
-    |> int.bitwise_or(0xE0)
-  let byte2 =
-    ord
-    |> int.bitwise_shift_right(0x06)
-    |> int.bitwise_and(0x3F)
-    |> int.bitwise_or(0x80)
-  let byte3 = ord |> int.bitwise_and(0x3F) |> int.bitwise_or(0x80)
-
-  <<byte1, byte2, byte3>>
-}
-
-fn bit_array_from_6_byte_ordinal(ord: Int) -> BitArray {
-  // 11101101 1010wwww 10xxxxxx 11101101 1011yyyy 10zzzzzz
-  let byte1 = 0xED
-  let byte2 =
-    { int.bitwise_shift_right(ord, 0x10) - 1 }
-    |> int.bitwise_and(0x0F)
-    |> int.bitwise_or(0xA0)
-  let byte3 =
-    ord
-    |> int.bitwise_shift_right(0x0A)
-    |> int.bitwise_and(0x3F)
-    |> int.bitwise_or(0x80)
-  let byte4 = 0xED
-  let byte5 =
-    ord
-    |> int.bitwise_shift_right(0x06)
-    |> int.bitwise_and(0x0F)
-    |> int.bitwise_or(0xB0)
-  let byte6 = ord |> int.bitwise_and(0x3F) |> int.bitwise_or(0x80)
-
-  <<byte1, byte2, byte3, byte4, byte5, byte6>>
 }
 
 // Decode
 
 pub fn string_from_bitarray(data: BitArray) -> Result(String, String) {
-  string_from_bitarray_impl([], data)
+  string_from_bitarray_impl(data, <<>>)
 }
 
 fn string_from_bitarray_impl(
-  into acc: List(UtfCodepoint),
-  from data: BitArray,
+  from: BitArray,
+  into: BitArray,
 ) -> Result(String, String) {
-  use expected_bytes <- result.try(get_expected_bytes(data))
-
-  case data, expected_bytes {
-    <<>>, 0 -> Ok(string.from_utf_codepoints(acc))
-
-    <<0, _rest:bits>>, _ -> Error("Embedded null byte in string bytes")
-
-    <<byte1, rest:bits>>, 1 -> {
-      use codepoint <- result.try(codepoint_from_1_byte(byte1))
-      string_from_bitarray_impl(list.append(acc, [codepoint]), rest)
-    }
-
-    <<byte1, byte2, rest:bits>>, 2 -> {
-      use codepoint <- result.try(codepoint_from_2_bytes(byte1, byte2))
-      string_from_bitarray_impl(list.append(acc, [codepoint]), rest)
-    }
-
-    <<byte1, byte2, byte3, rest:bits>>, 3 -> {
-      use codepoint <- result.try(codepoint_from_3_bytes(byte1, byte2, byte3))
-      string_from_bitarray_impl(list.append(acc, [codepoint]), rest)
-    }
-
-    <<byte1, byte2, byte3, byte4, byte5, byte6, rest:bits>>, 6 -> {
-      use codepoint <- result.try(codepoint_from_6_bytes(
-        byte1,
-        byte2,
-        byte3,
-        byte4,
-        byte5,
-        byte6,
-      ))
-      string_from_bitarray_impl(list.append(acc, [codepoint]), rest)
-    }
-
-    _, expected ->
-      Error(
-        "Expected a "
-        <> int.to_string(expected)
-        <> "-byte character but there weren't enough left",
-      )
-  }
-}
-
-fn get_expected_bytes(data: BitArray) -> Result(Int, String) {
-  case data {
-    <<>> -> Ok(0)
-
-    <<byte1, rest:bits>> ->
-      case int.bitwise_and(byte1, 0xE0), int.bitwise_and(byte1, 0xF0) {
-        0xC0, _ -> Ok(2)
-
-        _, 0xE0 ->
-          case rest {
-            <<byte2, _byte3, rest2:bits>> ->
-              case byte1, int.bitwise_and(byte2, 0xF0) {
-                0xED, 0xA0 ->
-                  case rest2 {
-                    <<byte4, byte5, _rest3:bits>> ->
-                      case byte4, int.bitwise_and(byte5, 0xF0) {
-                        0xED, 0xB0 -> Ok(6)
-
-                        _, _ -> Ok(3)
-                      }
-
-                    _ -> Ok(3)
-                  }
-
-                _, _ -> Ok(3)
-              }
-
-            _ ->
-              Error(
-                "Got an indicator for a 3 or 6 byte character but there aren't enough bytes left",
-              )
-          }
-
-        _, _ -> Ok(1)
+  case split_at_first_multibyte(from, 0) {
+    #(<<>>, rest) ->
+      case rest {
+        // Finished
+        <<>> ->
+          into
+          |> bit_array.to_string
+          |> result.map_error(fn(_) { "Failed to decode from mutf8 to utf8" })
+        // Null
+        <<0xC0, 0x80, rest:bits>> ->
+          string_from_bitarray_impl(rest, <<into:bits, 0>>)
+        // 2-byte
+        <<0b110:size(3), cont:bits-size(13), rest:bits>> ->
+          string_from_bitarray_impl(rest, <<
+            into:bits,
+            0b110:size(3),
+            cont:bits-size(13),
+          >>)
+        // 6-byte into 4-byte
+        <<
+          0xed,
+          0xa:size(4),
+          v:size(4),
+          0b10:size(2),
+          w:bits-size(4),
+          x:bits-size(2),
+          0xed,
+          0xb:size(4),
+          y:bits-size(4),
+          0b10:size(2),
+          z:bits-size(6),
+          rest:bits,
+        >> -> {
+          let v = v + 1
+          let assert <<t:bits-size(3), u:bits-size(2)>> = <<v:size(5)>>
+          string_from_bitarray_impl(rest, <<
+            into:bits,
+            0b11110:size(5),
+            t:bits-size(3),
+            0b10:size(2),
+            u:bits-size(2),
+            w:bits-size(4),
+            0b10:size(2),
+            x:bits-size(2),
+            y:bits-size(4),
+            0b10:size(2),
+            z:bits-size(6),
+          >>)
+        }
+        // 3-byte
+        <<0b1110:size(4), cont:bits-size(20), rest:bits>> ->
+          string_from_bitarray_impl(rest, <<
+            into:bits,
+            0b1110:size(4),
+            cont:bits-size(20),
+          >>)
+        // Invalid
+        _ -> {
+          let assert <<a, _rest:bits>> = rest
+          let assert Ok(bits) = int.to_base_string(a, 2)
+          Error(
+            "Unexpected bytes while encoding string to mutf8, expected the start of a multi-byte character, next byte is: 0x"
+            <> bits,
+          )
+        }
       }
 
-    _ -> Ok(1)
+    //Finished
+    #(mono_bytes, <<>>) ->
+      <<into:bits, mono_bytes:bits>>
+      |> bit_array.to_string
+      |> result.map_error(fn(_) { "Failed to decode from mutf8 to utf8" })
+
+    #(mono_bytes, rest) ->
+      string_from_bitarray_impl(rest, <<into:bits, mono_bytes:bits>>)
   }
 }
 
-fn codepoint_from_1_byte(byte1: Int) -> Result(UtfCodepoint, String) {
-  string.utf_codepoint(byte1)
-  |> result.replace_error(
-    "Cannot convert byte to a string char: " <> int.to_string(byte1),
-  )
-}
+fn split_at_first_multibyte(from: BitArray, at: Int) -> #(BitArray, BitArray) {
+  case from {
+    <<before:bits-size(at)>> -> #(before, <<>>)
 
-fn codepoint_from_2_bytes(
-  byte1: Int,
-  byte2: Int,
-) -> Result(UtfCodepoint, String) {
-  int.bitwise_and(byte1, 0x1F)
-  |> int.bitwise_shift_left(6)
-  |> int.bitwise_or(int.bitwise_and(byte2, 0x3F))
-  |> string.utf_codepoint
-  |> result.replace_error(
-    "Cannot convert bytes to a string char: "
-    <> bit_array.inspect(<<byte1, byte2>>),
-  )
-}
+    <<before:bits-size(at), 0, rest:bits>> -> #(before, <<0, rest:bits>>)
 
-fn codepoint_from_3_bytes(
-  byte1: Int,
-  byte2: Int,
-  byte3: Int,
-) -> Result(UtfCodepoint, String) {
-  int.bitwise_and(byte1, 0x0F)
-  |> int.bitwise_shift_left(0x0C)
-  |> int.bitwise_or(
-    int.bitwise_and(byte2, 0x3F) |> int.bitwise_shift_left(0x06),
-  )
-  |> int.bitwise_or(int.bitwise_and(byte3, 0x3F))
-  |> string.utf_codepoint
-  |> result.replace_error(
-    "Cannot convert bytes to a string char: "
-    <> bit_array.inspect(<<byte1, byte2, byte3>>),
-  )
-}
+    <<before:bits-size(at), 1:size(1), rest:bits>> -> #(before, <<
+      1:size(1),
+      rest:bits,
+    >>)
 
-fn codepoint_from_6_bytes(
-  byte1: Int,
-  byte2: Int,
-  byte3: Int,
-  byte4: Int,
-  byte5: Int,
-  byte6: Int,
-) -> Result(UtfCodepoint, String) {
-  0x10000
-  |> int.bitwise_or(
-    int.bitwise_and(byte2, 0x0F) |> int.bitwise_shift_left(0x10),
-  )
-  |> int.bitwise_or(
-    int.bitwise_and(byte3, 0x3F) |> int.bitwise_shift_left(0x0A),
-  )
-  |> int.bitwise_or(
-    int.bitwise_and(byte5, 0x0F) |> int.bitwise_shift_left(0x06),
-  )
-  |> int.bitwise_or(int.bitwise_and(byte6, 0x3F))
-  |> string.utf_codepoint
-  |> result.replace_error(
-    "Cannot convert bytes to a string char: "
-    <> bit_array.inspect(<<byte1, byte2, byte3, byte4, byte5, byte6>>),
-  )
+    <<_before:bits-size(at), 0:size(1), _rest:bits>> ->
+      split_at_first_multibyte(from, at + 8)
+
+    _ -> panic as "Unreachable"
+  }
 }

--- a/src/nbeet/internal/mutf8.gleam
+++ b/src/nbeet/internal/mutf8.gleam
@@ -160,6 +160,12 @@ fn split_at_special_cases(from: BitArray, at: Int) -> #(BitArray, BitArray) {
     <<before:bits-size(at), 0xed, 0xA:size(4), rest:bits>> -> #(before, <<
       0xed, 0xA:size(4), rest:bits,
     >>)
+    // 2-byte
+    <<_before:bits-size(at), 0b110:size(3), _rest:bits>> ->
+      split_at_special_cases(from, at + 16)
+    // 3-byte
+    <<_before:bits-size(at), 0b1110:size(4), _rest:bits>> ->
+      split_at_special_cases(from, at + 24)
     // Scan the next byte
     _ -> split_at_special_cases(from, at + 8)
   }

--- a/src/nbeet/internal/mutf8.gleam
+++ b/src/nbeet/internal/mutf8.gleam
@@ -28,61 +28,58 @@ fn bitarray_from_string_impl(
   case split_at_special_cases(from, 0) {
     // Finished
     #(ok_bytes, <<>>) -> Ok(<<into:bits, ok_bytes:bits>>)
-    // Special cases
-    #(ok_bytes, rest) ->
-      case rest {
-        // Finished
-        <<>> -> Ok(<<into:bits, ok_bytes:bits>>)
-        // Null
-        <<0, rest:bits>> ->
-          bitarray_from_string_impl(rest, <<
-            into:bits,
-            ok_bytes:bits,
-            0xC0,
-            0x80,
-          >>)
-        // 4-byte -> 6-byte
-        <<
-          0b11110:size(5),
-          t:bits-size(3),
-          0b10:size(2),
-          u:bits-size(2),
-          w:bits-size(4),
-          0b10:size(2),
-          x:bits-size(2),
-          y:bits-size(4),
-          0b10:size(2),
-          z:bits-size(6),
-          rest:bits,
-        >> -> {
-          let assert <<v>> = <<0b000:size(3), t:bits-size(3), u:bits-size(2)>>
-          let v = v - 1
-          bitarray_from_string_impl(rest, <<
-            into:bits,
-            ok_bytes:bits,
-            0xed,
-            0xa:size(4),
-            v:size(4),
-            0b10:size(2),
-            w:bits-size(4),
-            x:bits-size(2),
-            0xed,
-            0xb:size(4),
-            y:bits-size(4),
-            0b10:size(2),
-            z:bits-size(6),
-          >>)
-        }
-        // Invalid
-        _ -> {
-          let assert <<a, _rest:bits>> = rest
-          let assert Ok(bits) = int.to_base_string(a, 2)
-          Error(
-            "Unexpected bytes while encoding string to mutf8, expected the start of a multi-byte character, next byte is: 0x"
-            <> bits,
-          )
-        }
-      }
+    // Null
+    #(ok_bytes, <<0, rest:bits>>) ->
+      bitarray_from_string_impl(rest, <<
+        into:bits,
+        ok_bytes:bits,
+        0xC0,
+        0x80,
+      >>)
+    // 4-byte -> 6-byte
+    #(
+      ok_bytes,
+      <<
+        0b11110:size(5),
+        t:bits-size(3),
+        0b10:size(2),
+        u:bits-size(2),
+        w:bits-size(4),
+        0b10:size(2),
+        x:bits-size(2),
+        y:bits-size(4),
+        0b10:size(2),
+        z:bits-size(6),
+        rest:bits,
+      >>,
+    ) -> {
+      let assert <<v>> = <<0b000:size(3), t:bits-size(3), u:bits-size(2)>>
+      let v = v - 1
+      bitarray_from_string_impl(rest, <<
+        into:bits,
+        ok_bytes:bits,
+        0xed,
+        0xa:size(4),
+        v:size(4),
+        0b10:size(2),
+        w:bits-size(4),
+        x:bits-size(2),
+        0xed,
+        0xb:size(4),
+        y:bits-size(4),
+        0b10:size(2),
+        z:bits-size(6),
+      >>)
+    }
+    // Invalid
+    #(_, rest) -> {
+      let assert <<a, _rest:bits>> = rest
+      let assert Ok(bits) = int.to_base_string(a, 2)
+      Error(
+        "Unexpected byte while encoding string to mutf8, expected the start of a 4-byte character (0b11110xxx) or a null (0b00000000), next byte is: 0x"
+        <> bits,
+      )
+    }
   }
 }
 
@@ -102,59 +99,53 @@ fn string_from_bitarray_impl(
       <<into:bits, ok_bytes:bits>>
       |> bit_array.to_string
       |> result.map_error(fn(_) { "Failed to decode from mutf8 to utf8" })
-    // Special cases
-    #(ok_bytes, rest) ->
-      case rest {
-        // Finished
-        <<>> ->
-          <<into:bits, ok_bytes:bits>>
-          |> bit_array.to_string
-          |> result.map_error(fn(_) { "Failed to decode from mutf8 to utf8" })
-        // Null
-        <<0xC0, 0x80, rest:bits>> ->
-          string_from_bitarray_impl(rest, <<into:bits, ok_bytes:bits, 0>>)
-        // 6-byte into 4-byte
-        <<
-          0xed,
-          0xa:size(4),
-          v:size(4),
-          0b10:size(2),
-          w:bits-size(4),
-          x:bits-size(2),
-          0xed,
-          0xb:size(4),
-          y:bits-size(4),
-          0b10:size(2),
-          z:bits-size(6),
-          rest:bits,
-        >> -> {
-          let v = v + 1
-          let assert <<t:bits-size(3), u:bits-size(2)>> = <<v:size(5)>>
-          string_from_bitarray_impl(rest, <<
-            into:bits,
-            ok_bytes:bits,
-            0b11110:size(5),
-            t:bits-size(3),
-            0b10:size(2),
-            u:bits-size(2),
-            w:bits-size(4),
-            0b10:size(2),
-            x:bits-size(2),
-            y:bits-size(4),
-            0b10:size(2),
-            z:bits-size(6),
-          >>)
-        }
-        // Invalid
-        _ -> {
-          let assert <<a, _rest:bits>> = rest
-          let assert Ok(bits) = int.to_base_string(a, 2)
-          Error(
-            "Unexpected bytes while encoding string to mutf8, expected the start of a multi-byte character, next byte is: 0x"
-            <> bits,
-          )
-        }
-      }
+    // Null
+    #(ok_bytes, <<0xC0, 0x80, rest:bits>>) ->
+      string_from_bitarray_impl(rest, <<into:bits, ok_bytes:bits, 0>>)
+    // 6-byte into 4-byte
+    #(
+      ok_bytes,
+      <<
+        0xed,
+        0xa:size(4),
+        v:size(4),
+        0b10:size(2),
+        w:bits-size(4),
+        x:bits-size(2),
+        0xed,
+        0xb:size(4),
+        y:bits-size(4),
+        0b10:size(2),
+        z:bits-size(6),
+        rest:bits,
+      >>,
+    ) -> {
+      let v = v + 1
+      let assert <<t:bits-size(3), u:bits-size(2)>> = <<v:size(5)>>
+      string_from_bitarray_impl(rest, <<
+        into:bits,
+        ok_bytes:bits,
+        0b11110:size(5),
+        t:bits-size(3),
+        0b10:size(2),
+        u:bits-size(2),
+        w:bits-size(4),
+        0b10:size(2),
+        x:bits-size(2),
+        y:bits-size(4),
+        0b10:size(2),
+        z:bits-size(6),
+      >>)
+    }
+    // Invalid
+    #(_, rest) -> {
+      let assert <<a, _rest:bits>> = rest
+      let assert Ok(bits) = int.to_base_string(a, 2)
+      Error(
+        "Unexpected byte while encoding mutf8 to String, expected the start of a 6-byte character (0b11101101) or a null (0b00000000), next byte is: 0x"
+        <> bits,
+      )
+    }
   }
 }
 

--- a/src/nbeet/internal/mutf8.gleam
+++ b/src/nbeet/internal/mutf8.gleam
@@ -58,9 +58,19 @@ fn bitarray_from_string_impl(
           let assert <<v>> = <<0b000:size(3), t:bits-size(3), u:bits-size(2)>>
           let v = v - 1
           bitarray_from_string_impl(rest, <<
-            into:bits, ok_bytes:bits, 0xed, 0xa:size(4), v:size(4), 0b10:size(2),
-            w:bits-size(4), x:bits-size(2), 0xed, 0xb:size(4), y:bits-size(4),
-            0b10:size(2), z:bits-size(6),
+            into:bits,
+            ok_bytes:bits,
+            0xed,
+            0xa:size(4),
+            v:size(4),
+            0b10:size(2),
+            w:bits-size(4),
+            x:bits-size(2),
+            0xed,
+            0xb:size(4),
+            y:bits-size(4),
+            0b10:size(2),
+            z:bits-size(6),
           >>)
         }
         // Invalid
@@ -121,9 +131,18 @@ fn string_from_bitarray_impl(
           let v = v + 1
           let assert <<t:bits-size(3), u:bits-size(2)>> = <<v:size(5)>>
           string_from_bitarray_impl(rest, <<
-            into:bits, ok_bytes:bits, 0b11110:size(5), t:bits-size(3),
-            0b10:size(2), u:bits-size(2), w:bits-size(4), 0b10:size(2),
-            x:bits-size(2), y:bits-size(4), 0b10:size(2), z:bits-size(6),
+            into:bits,
+            ok_bytes:bits,
+            0b11110:size(5),
+            t:bits-size(3),
+            0b10:size(2),
+            u:bits-size(2),
+            w:bits-size(4),
+            0b10:size(2),
+            x:bits-size(2),
+            y:bits-size(4),
+            0b10:size(2),
+            z:bits-size(6),
           >>)
         }
         // Invalid

--- a/src/nbeet/internal/mutf8.gleam
+++ b/src/nbeet/internal/mutf8.gleam
@@ -72,14 +72,22 @@ fn bitarray_from_string_impl(
       >>)
     }
     // Invalid
-    #(_, rest) -> {
-      let assert <<a, _rest:bits>> = rest
-      let assert Ok(bits) = int.to_base_string(a, 2)
-      Error(
-        "Unexpected byte while encoding string to mutf8, expected the start of a 4-byte character (0b11110xxx) or a null (0b00000000), next byte is: 0x"
-        <> bits,
-      )
-    }
+    #(_, rest) ->
+      case rest {
+        <<a, _rest:bits>> -> {
+          let bits = int.to_base2(a)
+          Error(
+            "Unexpected byte while encoding string to mutf8, expected the start of a 4-byte character (0b11110xxx) or a null (0b00000000), next byte is: 0x"
+            <> bits,
+          )
+        }
+
+        _ ->
+          Error(
+            "Less than 1 byte remaining in String while encoding String to mutf8. "
+            <> "This shouldn't happen, this is a bug.",
+          )
+      }
   }
 }
 
@@ -138,14 +146,22 @@ fn string_from_bitarray_impl(
       >>)
     }
     // Invalid
-    #(_, rest) -> {
-      let assert <<a, _rest:bits>> = rest
-      let assert Ok(bits) = int.to_base_string(a, 2)
-      Error(
-        "Unexpected byte while encoding mutf8 to String, expected the start of a 6-byte character (0b11101101) or a null (0b00000000), next byte is: 0x"
-        <> bits,
-      )
-    }
+    #(_, rest) ->
+      case rest {
+        <<a, _rest:bits>> -> {
+          let bits = int.to_base2(a)
+          Error(
+            "Unexpected byte while encoding mutf8 to String, expected the start of a 6-byte character (0b11101101) or a null (0b00000000), next byte is: 0x"
+            <> bits,
+          )
+        }
+
+        _ ->
+          Error(
+            "Less than 1 byte remaining in bit-string while encoding mutf8 to String. "
+            <> "This shouldn't happen, either the passed bit-array does not contain a multiple of 8 bits or this is a bug in the string conversion code.",
+          )
+      }
   }
 }
 

--- a/src/nbeet/internal/mutf8.gleam
+++ b/src/nbeet/internal/mutf8.gleam
@@ -9,6 +9,11 @@ import gleam/result
 //  2-byte  110xxxyy 10yyzzzz                   <----------------same-----------------> 110xxxyy 10yyzzzz
 //  3-byte  1110wwww 10xxxxyy 10yyzzzz          <----------------same-----------------> 1110wwww 10xxxxyy 10yyzzzz
 //  4-byte  11110vvv 10vvwwww 10xxxxyy 10yyzzzz <-v is decremented and cast to 4 bits-> 11101101 1010vvvv 10wwwwxx 11101101 1011xxyy 10yyzzzz
+//
+// Continuation bytes all start with bits `10`. The special cases have
+// starting bytes that do not clash with this in either conversion direction
+// This means we can use a sliding window to scan ahead for the special cases
+// and move all bytes before a match straight into the output
 
 // Encode
 
@@ -20,27 +25,21 @@ fn bitarray_from_string_impl(
   from: BitArray,
   into: BitArray,
 ) -> Result(BitArray, String) {
-  case split_at_first_multibyte(from, 0) {
-    #(<<>>, rest) ->
+  case split_at_special_cases(from, 0) {
+    // Finished
+    #(ok_bytes, <<>>) -> Ok(<<into:bits, ok_bytes:bits>>)
+    // Special cases
+    #(ok_bytes, rest) ->
       case rest {
         // Finished
-        <<>> -> Ok(into)
+        <<>> -> Ok(<<into:bits, ok_bytes:bits>>)
         // Null
         <<0, rest:bits>> ->
-          bitarray_from_string_impl(rest, <<into:bits, 0xC0, 0x80>>)
-        // 2-byte
-        <<0b110:size(3), cont:bits-size(13), rest:bits>> ->
           bitarray_from_string_impl(rest, <<
             into:bits,
-            0b110:size(3),
-            cont:bits-size(13),
-          >>)
-        // 3-byte
-        <<0b1110:size(4), cont:bits-size(20), rest:bits>> ->
-          bitarray_from_string_impl(rest, <<
-            into:bits,
-            0b1110:size(4),
-            cont:bits-size(20),
+            ok_bytes:bits,
+            0xC0,
+            0x80,
           >>)
         // 4-byte -> 6-byte
         <<
@@ -59,18 +58,9 @@ fn bitarray_from_string_impl(
           let assert <<v>> = <<0b000:size(3), t:bits-size(3), u:bits-size(2)>>
           let v = v - 1
           bitarray_from_string_impl(rest, <<
-            into:bits,
-            0xed,
-            0xa:size(4),
-            v:size(4),
-            0b10:size(2),
-            w:bits-size(4),
-            x:bits-size(2),
-            0xed,
-            0xb:size(4),
-            y:bits-size(4),
-            0b10:size(2),
-            z:bits-size(6),
+            into:bits, ok_bytes:bits, 0xed, 0xa:size(4), v:size(4), 0b10:size(2),
+            w:bits-size(4), x:bits-size(2), 0xed, 0xb:size(4), y:bits-size(4),
+            0b10:size(2), z:bits-size(6),
           >>)
         }
         // Invalid
@@ -83,11 +73,6 @@ fn bitarray_from_string_impl(
           )
         }
       }
-
-    #(mono_bytes, <<>>) -> Ok(<<into:bits, mono_bytes:bits>>)
-
-    #(mono_bytes, rest) ->
-      bitarray_from_string_impl(rest, <<into:bits, mono_bytes:bits>>)
   }
 }
 
@@ -101,24 +86,23 @@ fn string_from_bitarray_impl(
   from: BitArray,
   into: BitArray,
 ) -> Result(String, String) {
-  case split_at_first_multibyte(from, 0) {
-    #(<<>>, rest) ->
+  case split_at_special_cases(from, 0) {
+    // Finished
+    #(ok_bytes, <<>>) ->
+      <<into:bits, ok_bytes:bits>>
+      |> bit_array.to_string
+      |> result.map_error(fn(_) { "Failed to decode from mutf8 to utf8" })
+    // Special cases
+    #(ok_bytes, rest) ->
       case rest {
         // Finished
         <<>> ->
-          into
+          <<into:bits, ok_bytes:bits>>
           |> bit_array.to_string
           |> result.map_error(fn(_) { "Failed to decode from mutf8 to utf8" })
         // Null
         <<0xC0, 0x80, rest:bits>> ->
-          string_from_bitarray_impl(rest, <<into:bits, 0>>)
-        // 2-byte
-        <<0b110:size(3), cont:bits-size(13), rest:bits>> ->
-          string_from_bitarray_impl(rest, <<
-            into:bits,
-            0b110:size(3),
-            cont:bits-size(13),
-          >>)
+          string_from_bitarray_impl(rest, <<into:bits, ok_bytes:bits, 0>>)
         // 6-byte into 4-byte
         <<
           0xed,
@@ -137,26 +121,11 @@ fn string_from_bitarray_impl(
           let v = v + 1
           let assert <<t:bits-size(3), u:bits-size(2)>> = <<v:size(5)>>
           string_from_bitarray_impl(rest, <<
-            into:bits,
-            0b11110:size(5),
-            t:bits-size(3),
-            0b10:size(2),
-            u:bits-size(2),
-            w:bits-size(4),
-            0b10:size(2),
-            x:bits-size(2),
-            y:bits-size(4),
-            0b10:size(2),
-            z:bits-size(6),
+            into:bits, ok_bytes:bits, 0b11110:size(5), t:bits-size(3),
+            0b10:size(2), u:bits-size(2), w:bits-size(4), 0b10:size(2),
+            x:bits-size(2), y:bits-size(4), 0b10:size(2), z:bits-size(6),
           >>)
         }
-        // 3-byte
-        <<0b1110:size(4), cont:bits-size(20), rest:bits>> ->
-          string_from_bitarray_impl(rest, <<
-            into:bits,
-            0b1110:size(4),
-            cont:bits-size(20),
-          >>)
         // Invalid
         _ -> {
           let assert <<a, _rest:bits>> = rest
@@ -167,32 +136,31 @@ fn string_from_bitarray_impl(
           )
         }
       }
-
-    //Finished
-    #(mono_bytes, <<>>) ->
-      <<into:bits, mono_bytes:bits>>
-      |> bit_array.to_string
-      |> result.map_error(fn(_) { "Failed to decode from mutf8 to utf8" })
-
-    #(mono_bytes, rest) ->
-      string_from_bitarray_impl(rest, <<into:bits, mono_bytes:bits>>)
   }
 }
 
-fn split_at_first_multibyte(from: BitArray, at: Int) -> #(BitArray, BitArray) {
+fn split_at_special_cases(from: BitArray, at: Int) -> #(BitArray, BitArray) {
   case from {
+    // Finished
     <<before:bits-size(at)>> -> #(before, <<>>)
-
+    // Null utf8
     <<before:bits-size(at), 0, rest:bits>> -> #(before, <<0, rest:bits>>)
-
-    <<before:bits-size(at), 1:size(1), rest:bits>> -> #(before, <<
-      1:size(1),
+    // Null mutf8
+    <<before:bits-size(at), 0xc0, 0x80, rest:bits>> -> #(before, <<
+      0xc0,
+      0x80,
       rest:bits,
     >>)
-
-    <<_before:bits-size(at), 0:size(1), _rest:bits>> ->
-      split_at_first_multibyte(from, at + 8)
-
-    _ -> panic as "Unreachable"
+    // 4-byte utf8
+    <<before:bits-size(at), 0b11110:size(5), rest:bits>> -> #(before, <<
+      0b11110:size(5),
+      rest:bits,
+    >>)
+    // 6-byte mutf8
+    <<before:bits-size(at), 0xed, 0xA:size(4), rest:bits>> -> #(before, <<
+      0xed, 0xA:size(4), rest:bits,
+    >>)
+    // Scan the next byte
+    _ -> split_at_special_cases(from, at + 8)
   }
 }

--- a/test/mutf8_test.gleam
+++ b/test/mutf8_test.gleam
@@ -1,6 +1,4 @@
-import gleam/bit_array
 import gleam/dict
-import gleeunit/should
 import nbeet/internal/mutf8
 
 fn cases() {
@@ -25,18 +23,18 @@ fn cases() {
 
 fn from_bit_array_case(c: String) {
   case cases() |> dict.get(c) {
-    Ok(#(s, b)) -> b |> mutf8.string_from_bitarray() |> should.equal(Ok(s))
+    Ok(#(s, b)) -> {
+      #(Ok(s), b |> mutf8.string_from_bitarray())
+    }
     Error(_) -> panic as { "Missing from bit array test case: " <> c }
   }
 }
 
 fn from_string_case(c: String) {
   case cases() |> dict.get(c) {
-    Ok(#(s, b)) ->
-      s
-      |> mutf8.bitarray_from_string()
-      |> bit_array.inspect()
-      |> should.equal(b |> bit_array.inspect())
+    Ok(#(s, b)) -> {
+      #(Ok(b), s |> mutf8.bitarray_from_string())
+    }
     Error(_) -> panic as { "Missing from bit array test case: " <> c }
   }
 }
@@ -44,67 +42,83 @@ fn from_string_case(c: String) {
 // From bit_array
 
 pub fn null_from_bitarray_test() {
-  "null" |> from_bit_array_case
+  let #(s, b) = "null" |> from_bit_array_case
+  assert s == b
 }
 
 pub fn latin_2_with_stroke_from_bitarray_test() {
-  "latin_2_with_stroke" |> from_bit_array_case
+  let #(s, b) = "latin_2_with_stroke" |> from_bit_array_case
+  assert s == b
 }
 
 pub fn canadian_syllabics_e_from_bitarray_test() {
-  "canadian_syllabics_e" |> from_bit_array_case
+  let #(s, b) = "canadian_syllabics_e" |> from_bit_array_case
+  assert s == b
 }
 
 pub fn square_kb_from_bitarray_test() {
-  "square_kb" |> from_bit_array_case
+  let #(s, b) = "square_kb" |> from_bit_array_case
+  assert s == b
 }
 
 pub fn katakana_tu_from_bitarray_test() {
-  "katakana_tu" |> from_bit_array_case
+  let #(s, b) = "katakana_tu" |> from_bit_array_case
+  assert s == b
 }
 
 pub fn korean_from_bitarray_test() {
-  "korean" |> from_bit_array_case
+  let #(s, b) = "korean" |> from_bit_array_case
+  assert s == b
 }
 
 pub fn deseret_long_e_capital_from_bitarray_test() {
-  "deseret_long_e_capital" |> from_bit_array_case
+  let #(s, b) = "deseret_long_e_capital" |> from_bit_array_case
+  assert s == b
 }
 
 pub fn deseret_short_a_capital_from_bitarray_test() {
-  "deseret_short_a_capital" |> from_bit_array_case
+  let #(s, b) = "deseret_short_a_capital" |> from_bit_array_case
+  assert s == b
 }
 
 // From string
 
 pub fn null_from_string_test() {
-  "null" |> from_string_case
+  let #(b, s) = "null" |> from_string_case
+  assert b == s
 }
 
 pub fn latin_2_with_stroke_from_string_test() {
-  "latin_2_with_stroke" |> from_string_case
+  let #(b, s) = "latin_2_with_stroke" |> from_string_case
+  assert b == s
 }
 
 pub fn canadian_syllabics_e_from_string_test() {
-  "canadian_syllabics_e" |> from_string_case
+  let #(b, s) = "canadian_syllabics_e" |> from_string_case
+  assert b == s
 }
 
 pub fn square_kb_from_string_test() {
-  "square_kb" |> from_string_case
+  let #(b, s) = "square_kb" |> from_string_case
+  assert b == s
 }
 
 pub fn katakana_tu_from_string_test() {
-  "katakana_tu" |> from_string_case
+  let #(b, s) = "katakana_tu" |> from_string_case
+  assert b == s
 }
 
 pub fn korean_from_string_test() {
-  "korean" |> from_string_case
+  let #(b, s) = "korean" |> from_string_case
+  assert b == s
 }
 
 pub fn deseret_long_e_capital_from_string_test() {
-  "deseret_long_e_capital" |> from_string_case
+  let #(b, s) = "deseret_long_e_capital" |> from_string_case
+  assert b == s
 }
 
 pub fn deseret_short_a_capital_from_string_test() {
-  "deseret_short_a_capital" |> from_string_case
+  let #(b, s) = "deseret_short_a_capital" |> from_string_case
+  assert b == s
 }


### PR DESCRIPTION
The original implementation had many inefficiencies. This new implementation:

- Scans ahead using a sliding window for special cases
  - Reduces bit array copying
  - A string without nulls and with codepoints at or below U+FFFF will be scanned only
- Directly converts bytes and not via codepoints

We do however lose the error messages that explain why a conversion failed.